### PR TITLE
Improve class initialization

### DIFF
--- a/example/src/components/metric.py
+++ b/example/src/components/metric.py
@@ -10,7 +10,6 @@ class MetricComponent(Component):
     ):
         super().__init__(component_id, {"value": None})
         self.header = header
-        print("init")
 
     def render(self):
         st.metric(self.header, self.state.value)

--- a/src/ststeroids/store.py
+++ b/src/ststeroids/store.py
@@ -93,8 +93,8 @@ class ComponentStore(Store):
         :param component_id: The unique identifier for the component.
         :return: None
         """
-        # if not self.has_property(component.id):
-        super().set_property(component.id, component)
+        if not self.has_property(component.id):
+            super().set_property(component.id, component)
 
     def init_component_state(self, component_id: str, initial_state: dict) -> None:
         """


### PR DESCRIPTION
Makes every component instance a singleton (per component_id) and returns the instance from the store if it already exists. It also make sure that the __init__ of a sub class is only run the first time on instance creation to avoid weird class behaviour.