### PR TITLE
Use Streamlit pages for navigation so the page is visible in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run the example app, execute the following commands from the project root:
 
 ```
 pip install -r requirements.txt
-streamlit run ./example/src/app.py
+streamlit run --client.showSidebarNavigation=False ./example/src/app.py
 ```
 
 To run the tests, execute the following command from the project root:

--- a/example/src/components/sidebar.py
+++ b/example/src/components/sidebar.py
@@ -8,35 +8,8 @@ class SidebarComponent(Component):
         super().__init__(component_id)
         self.router = router
 
-    def __on_menu_item_click(self, item):
-        self.router.route(item)
-
-    def __get_titles(self):
-        current_route = self.router.get_current_route()
-        dashboard_title = "Dashboard"
-        view_data_title = "View data"
-
-        if current_route == "dashboard":
-            dashboard_title = f"**:primary-background[{dashboard_title}]**"
-        if current_route == "manage_data":
-            view_data_title = f"**:primary-background[{view_data_title}]**"
-
-        return dashboard_title, view_data_title
-
     def render(self):
-        dashboard_title, view_data_title = self.__get_titles()
         with st.sidebar:
-            st.button(
-                dashboard_title,
-                icon=":material/search:",
-                type="tertiary",
-                on_click=self.__on_menu_item_click,
-                kwargs={"item": "dashboard"},
-            )
-            st.button(
-                view_data_title,
-                icon=":material/bar_chart:",
-                type="tertiary",
-                on_click=self.__on_menu_item_click,
-                kwargs={"item": "manage_data"},
-            )
+            st.page_link("pages/dashboard.py", icon=":material/search:", label="Dashboard")
+            st.page_link("pages/manage.py", icon=":material/bar_chart:", label="Manage data")
+     

--- a/example/src/main.py
+++ b/example/src/main.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+import streamlit as st
+from components import SidebarComponent
+from flows import LoginFlow, LoginSuccessFlow, RefreshFlow
+from layouts import LoginLayout, DashboardLayout, ManageDataLayout
+from service import MockBackendService
+from ststeroids import Router, Store, Style
+
+class MainApp:
+
+    def __init__(self):
+        self.session_store = Store("store")
+        self.router = Router("login")
+
+        self.backend_service = MockBackendService("./example/test_data.json")
+        self.login_flow = LoginFlow(self.session_store, self.backend_service)
+        self.login_success_flow = LoginSuccessFlow(self.router, self.session_store, self.backend_service)
+        self.refresh_flow = RefreshFlow(self.session_store, self.backend_service)
+
+        st.set_page_config(page_title="StSteroids Example app", layout="wide")
+
+        app_style = Style("./example/src/assets/style.css")
+        app_style.apply_style()
+
+        self.login_layout = LoginLayout("App login", self.login_flow, self.login_success_flow)
+        self.dashboard_layout = DashboardLayout(self.refresh_flow)
+        self.manage_data_layout = ManageDataLayout()
+
+        self.sidebar = SidebarComponent("sidebar", self.router)
+    
+    def run(self, entry_route:str = None):
+        self.sidebar.render()
+
+        def get_routes():
+            routes = defaultdict(lambda: self.login_layout)
+            routes["login"] = self.login_layout
+
+            if self.session_store.has_property("access_token"):
+                routes.update(
+                    {
+                        "dashboard": self.dashboard_layout,
+                        "manage_data": self.manage_data_layout,
+                    },
+                )
+
+            return routes
+
+        self.router.register_routes(get_routes())
+        if entry_route:
+            self.router.route(entry_route)
+        self.router.run()

--- a/example/src/pages/dashboard.py
+++ b/example/src/pages/dashboard.py
@@ -2,4 +2,4 @@ from main import MainApp
 
 app = MainApp()
 
-app.run()
+app.run("dashboard")

--- a/example/src/pages/manage.py
+++ b/example/src/pages/manage.py
@@ -2,4 +2,4 @@ from main import MainApp
 
 app = MainApp()
 
-app.run()
+app.run("manage_data")


### PR DESCRIPTION
Updated the example app to use Streamlit’s pages functionality, making the URL reflect the current page. This can be useful in various authorization use cases.