### PR TITLE
Improve execute_render

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ app_style.apply_style()
 
 ### Release notes
 
+0.1.17
+
+- Improved execute_render function by adding an error handler
+- Default refresh_interval for a fragment is now `None` to avoid unintended refreshes
+
 0.1.16
 
 - Improved component instance creation by making component instances a singleton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ststeroids"
-version = "0.1.16"
+version = "0.1.17"
 description = "A framework supercharging Streamlit for building advanced multi-page applications"
 readme = "README.md"
 authors = [{ name = "ponsoc"}]

--- a/src/ststeroids/component.py
+++ b/src/ststeroids/component.py
@@ -112,7 +112,7 @@ class Component:
 
         _render()
 
-    def _render_fragment(self, refresh_interval: str = "5s", refresh_flow: Flow = None):
+    def _render_fragment(self, refresh_interval: str = None, refresh_flow: Flow = None):
         """
         Internal method for rendering the component as a fragment.
 
@@ -152,6 +152,7 @@ class Component:
                 return self._render_dialog(**options)
             case "fragment":
                 return self._render_fragment(**options)
+        raise ValueError(f"Unexpected render_as value: {render_as}")
 
     def render(self) -> None:
         """

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -143,3 +143,7 @@ def test_execute_render_fragment(component):
     result = component.execute_render(render_as="fragment", options={"x": 1})
     component._render_fragment.assert_called_once_with(x=1)
     assert result == "fragment_rendered"
+
+def test_execute_render_raises_an_error_with_an_invalid_render_as(component):
+    with pytest.raises(ValueError):
+        component.execute_render(render_as="something", options={"x": 1})


### PR DESCRIPTION
- Improved execute_render function by adding an error handler
- Default refresh_interval for a fragment is now `None` to avoid unintended refreshes